### PR TITLE
Update "get-user-teams-membership" action to use Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Therefore rather than having to turn off for everyone and some miss out on the v
 2. Add this action
   ```yaml
     - name: Turn off PR comments for users in 'Suppress PR test summary comments'
-      uses: eloisetaylor5693/turn-off-pr-comments-for-test-summary-github-action@v1.0.2
+      uses: eloisetaylor5693/turn-off-pr-comments-for-test-summary-github-action@v2.0.0
       id: suppress-pr-comments-for-some-users
       with:
         default_comment_mode: 'failures'

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
     run:  echo "TEST_SUMMARY_COMMENT_MODE=${{ inputs.default_comment_mode}}" >> $GITHUB_ENV
     
   - name: Check if user is a member of the team
-    uses: tspascoal/get-user-teams-membership@v2
+    uses: tspascoal/get-user-teams-membership@v3
     id: check_if_user_suppressed_comments
     with:
       username: ${{ github.actor }}


### PR DESCRIPTION
Version 2 of the `get-user-teams-membership` action uses Node 16, which considered is end of life and results in warnings on Github Actions workflow runs [1].

This commit updates to version 3 of `get-user-teams-membership`, which uses a version of Node with long term support (version 20) [2].

[1] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
[2] https://github.com/tspascoal/get-user-teams-membership/releases/tag/v3.0.0