### PR TITLE
Specify correct version number for get-user-teams-memberships

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Therefore rather than having to turn off for everyone and some miss out on the v
 2. Add this action
   ```yaml
     - name: Turn off PR comments for users in 'Suppress PR test summary comments'
-      uses: eloisetaylor5693/turn-off-pr-comments-for-test-summary-github-action@v2.0.0
+      uses: eloisetaylor5693/turn-off-pr-comments-for-test-summary-github-action@v2.0.1
       id: suppress-pr-comments-for-some-users
       with:
         default_comment_mode: 'failures'

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
     run:  echo "TEST_SUMMARY_COMMENT_MODE=${{ inputs.default_comment_mode}}" >> $GITHUB_ENV
     
   - name: Check if user is a member of the team
-    uses: tspascoal/get-user-teams-membership@v3
+    uses: tspascoal/get-user-teams-membership@v3.0.0
     id: check_if_user_suppressed_comments
     with:
       username: ${{ github.actor }}


### PR DESCRIPTION
I'd previously updated the `tspascoal/get-user-teams-membership` dependency in [1] to fix Node 16 warnings on Github Action workflow runs.

Despite following the repo's README instructions to use the "v3" ref, I'd noticed that we were still getting Node 16 warnings.

It turns out that the v3 release tag [2] doesn't include in the Node 16 fix, but the v3.0.0 release tag [3] does, so this commit updates to use that ref instead.

[1] 9fab6aa9f470a42f49771597373edd6bcf1d3003
[2] https://github.com/tspascoal/get-user-teams-membership/releases/tag/v3
[3] https://github.com/tspascoal/get-user-teams-membership/releases/tag/v3.0.0